### PR TITLE
Create Dockerfiles for HBase-1.3.2

### DIFF
--- a/distributed-1.3.2-hadoop-2.7.3/Dockerfile
+++ b/distributed-1.3.2-hadoop-2.7.3/Dockerfile
@@ -1,0 +1,29 @@
+FROM danisla/hadoop:2.7.3
+
+ENV VERSION 1.3.2
+ENV DESTINATION /opt/hbase
+
+WORKDIR /
+
+ADD http://archive.apache.org/dist/hbase/${VERSION}/hbase-${VERSION}-bin.tar.gz /
+RUN tar -xvf /hbase-${VERSION}-bin.tar.gz
+RUN ls /
+RUN mv /hbase-${VERSION} ${DESTINATION}
+
+# REST API
+EXPOSE 8080
+# Thrift API
+EXPOSE 9090
+
+# Zookeeper port
+EXPOSE 2181
+
+# Master port
+EXPOSE 16000
+# Master info port
+EXPOSE 16010
+
+# Regionserver port
+EXPOSE 16020
+# Regionserver info port
+EXPOSE 16030

--- a/standalone-1.3.2-embedded-zk/Dockerfile
+++ b/standalone-1.3.2-embedded-zk/Dockerfile
@@ -1,0 +1,47 @@
+FROM openjdk:8
+
+RUN apt-get update
+RUN apt-get -y install supervisor python-pip net-tools vim
+RUN pip install supervisor-stdout
+RUN mkdir -p /var/log/supervisor
+COPY supervisord.conf /etc/supervisor/conf.d/supervisord.conf
+
+ENV VERSION 1.3.2
+ENV DESTINATION /opt/hbase
+
+ADD http://archive.apache.org/dist/hbase/${VERSION}/hbase-${VERSION}-bin.tar.gz /
+RUN tar -xvf hbase-${VERSION}-bin.tar.gz
+RUN mv /hbase-${VERSION} ${DESTINATION}
+ADD hbase-site.xml /${DESTINATION}/conf/hbase-site.xml
+
+# Folder for data
+RUN mkdir -p /data/hbase
+RUN mkdir -p /data/zookeeper
+
+ENV JAVA_HOME /usr/lib/jvm/java-8-openjdk-amd64
+ENV PATH $PATH:/${DESTINATION}/bin
+
+# REST API
+EXPOSE 8080
+# Thrift API
+EXPOSE 9090
+
+# Zookeeper port
+EXPOSE 2181
+
+# Master port
+EXPOSE 16000
+# Master info port
+EXPOSE 16010
+
+# Regionserver port
+EXPOSE 16020
+# Regionserver info port
+EXPOSE 16030
+
+VOLUME /data/hbase
+VOLUME /data/zookeeper
+WORKDIR ${DESTINATION}
+
+
+CMD ["/usr/bin/supervisord"]

--- a/standalone-1.3.2-embedded-zk/hbase-site.xml
+++ b/standalone-1.3.2-embedded-zk/hbase-site.xml
@@ -1,0 +1,11 @@
+<configuration>
+  <property>
+    <name>hbase.rootdir</name>
+    <value>file:///data2/hbase</value>
+  </property>
+  <property>
+    <name>hbase.zookeeper.property.dataDir</name>
+    <value>/data2/zookeeper</value>
+  </property>
+
+</configuration>

--- a/standalone-1.3.2-embedded-zk/supervisord.conf
+++ b/standalone-1.3.2-embedded-zk/supervisord.conf
@@ -1,0 +1,15 @@
+[supervisord]
+nodaemon=true
+
+[program:hbase]
+command=/opt/hbase/bin/hbase master start
+stdout_events_enabled=true
+stderr_events_enabled=true
+stdout_logfile=/dev/stdout
+stdout_logfile_maxbytes=0
+
+[eventlistener:stdout]
+command = supervisor_stdout
+buffer_size = 100
+events = PROCESS_LOG
+result_handler = supervisor_stdout:event_handler

--- a/standalone-1.3.2/Dockerfile
+++ b/standalone-1.3.2/Dockerfile
@@ -1,0 +1,51 @@
+FROM openjdk:8
+
+RUN apt-get update
+RUN apt-get -y install supervisor python-pip net-tools vim
+RUN pip install supervisor-stdout
+RUN mkdir -p /var/log/supervisor
+COPY supervisord.conf /etc/supervisor/conf.d/supervisord.conf
+
+ENV VERSION 1.3.2
+ENV DESTINATION /opt/hbase
+
+ADD http://archive.apache.org/dist/hbase/${VERSION}/hbase-${VERSION}-bin.tar.gz /
+RUN tar -xvf hbase-${VERSION}-bin.tar.gz
+RUN mv /hbase-${VERSION} ${DESTINATION}
+ADD hbase-site.xml /${DESTINATION}/conf/hbase-site.xml
+
+# Folder for data
+RUN mkdir -p /data/hbase
+RUN mkdir -p /data/zookeeper
+
+ENV JAVA_HOME /usr/lib/jvm/java-8-openjdk-amd64
+ENV PATH $PATH:/${DESTINATION}/bin
+
+# Getting web-for-it
+RUN wget https://raw.githubusercontent.com/vishnubob/wait-for-it/master/wait-for-it.sh -O /wait-for-it.sh
+RUN chmod +x /wait-for-it.sh
+
+# REST API
+EXPOSE 8080
+# Thrift API
+EXPOSE 9090
+
+# Zookeeper port
+EXPOSE 2181
+
+# Master port
+EXPOSE 16000
+# Master info port
+EXPOSE 16010
+
+# Regionserver port
+EXPOSE 16020
+# Regionserver info port
+EXPOSE 16030
+
+VOLUME /data/hbase
+VOLUME /data/zookeeper
+WORKDIR ${DESTINATION}
+
+
+CMD ["/usr/bin/supervisord"]

--- a/standalone-1.3.2/hbase-site.xml
+++ b/standalone-1.3.2/hbase-site.xml
@@ -1,0 +1,19 @@
+<configuration>
+  <property>
+    <name>hbase.rootdir</name>
+    <value>file:///data2/hbase</value>
+  </property>
+  <property>
+    <name>hbase.zookeeper.property.dataDir</name>
+    <value>/data2/zookeeper</value>
+  </property>
+     <property>
+     <name>hbase.zookeeper.quorum</name>
+     <value>zookeeper</value>
+   </property>
+   <property>
+     <name>hbase.zookeeper.property.ClientPort</name>
+     <value>2181</value>
+   </property>
+
+</configuration>

--- a/standalone-1.3.2/supervisord.conf
+++ b/standalone-1.3.2/supervisord.conf
@@ -1,0 +1,15 @@
+[supervisord]
+nodaemon=true
+
+[program:hbase]
+command=/opt/hbase/bin/hbase master start
+stdout_events_enabled=true
+stderr_events_enabled=true
+stdout_logfile=/dev/stdout
+stdout_logfile_maxbytes=0
+
+[eventlistener:stdout]
+command = supervisor_stdout
+buffer_size = 100
+events = PROCESS_LOG
+result_handler = supervisor_stdout:event_handler


### PR DESCRIPTION
This PR adds HBase-1.3.2 functionality.  It is a very simple update.  I needed HBase-1.3.2 to solve a bug in opentsdb; I've tested it locally in my environment and it worked without issues, at least for the distributed-1.3.2-hadoop-2.7.3 recipe.  The other recipes I did the same change (updated version to 1.3.2) and I assume they will also work fine.